### PR TITLE
Add dependencies to run Voila App on Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # work-in-progress demo
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/mkcor/voila-reveal-example/master)
+Launch [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/mkcor/voila-reveal-example/master)
+
+Launch Voila on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mkcor/voila-reveal-example.git/master?filepath=%2Fvoila%2Frender%2Findex.ipynb)
 
 Example Jupyter notebook to run as a standalone web application with
 [Voila](https://github.com/QuantStack/voila), meant to render as a

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,6 @@ dependencies:
 - pandas=0.25.1
 - plotly=4.1.0
 - voila=0.1.10
+- pip
+- pip:
+  - voila-reveal

--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -1,0 +1,5 @@
+{
+  "VoilaConfiguration": {
+    "template": "reveal"
+  }
+}


### PR DESCRIPTION

Added the dependencies necessary to run the app on Binder and landing directly on the slides.

As seen here
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/akielbowicz/voila-reveal-example.git/master?urlpath=%2Fvoila%2Frender%2Findex.ipynb)